### PR TITLE
added connection string option to configuration

### DIFF
--- a/Sources/AMQPClient/AMQPClientConfiguration.swift
+++ b/Sources/AMQPClient/AMQPClientConfiguration.swift
@@ -27,13 +27,13 @@ public enum AMQPClientConfiguration {
     }
     
     public struct Server {
-        var host: String
-        var port: Int
-        var user: String
-        var password: String
-        var vhost: String
-        var timeout: TimeAmount
-        var connectionName: String
+        public var host: String
+        public var port: Int
+        public var user: String
+        public var password: String
+        public var vhost: String
+        public var timeout: TimeAmount
+        public var connectionName: String
         
         public init(host: String? = nil,
                     port: Int? = nil,
@@ -56,12 +56,7 @@ public enum AMQPClientConfiguration {
 
 @available(macOS 13.0, *)
 public extension AMQPClientConfiguration {
-    
-    enum ValidationError: Error, Equatable {
-        case invalidUrl
-        case invalidScheme
-    }
-    
+
     enum UrlScheme: String {
         case amqp = "amqp"
         case amqps = "amqps"
@@ -75,12 +70,12 @@ public extension AMQPClientConfiguration {
     }
     
     init(url: String) throws {
-        guard let url = URL(string: url) else { throw ValidationError.invalidUrl }
+        guard let url = URL(string: url) else { throw AMQPClientError.invalidUrl }
         try self.init(url: url)
     }
     
     init(url: URL) throws {
-        guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw ValidationError.invalidScheme }
+        guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw AMQPClientError.invalidUrlScheme }
         
         // there is no such thing as a "" host
         let host = url.host?.isEmpty == true ? nil : url.host

--- a/Sources/AMQPClient/AMQPClientConfiguration.swift
+++ b/Sources/AMQPClient/AMQPClientConfiguration.swift
@@ -11,31 +11,100 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import NIOSSL
-import NIO
+import NIOCore
+import Foundation
 
 public enum AMQPClientConfiguration {
     case tls(TLSConfiguration?, sniServerName: String?, Server)
     case plain(Server)
-
-    public struct Server {
-        let host: String
-        let port: Int
-        let user: String
-        let password: String
-        let vhost: String
-        let timeout: TimeAmount
-        let connectionName: String
-
-        public init(host: String = "localhost", port: Int = 5672, user: String = "guest", password: String = "guest", vhost: String = "/", timeout: TimeAmount = TimeAmount.seconds(60), connectionName: String = ((Bundle.main.executablePath ?? "RabbitMQNIO") as NSString).lastPathComponent) {
-            self.host = host
-            self.port = port
-            self.user = user
-            self.password = password
-            self.vhost = vhost
-            self.timeout = timeout
-            self.connectionName = connectionName
+    
+    var server: Server {
+        switch self {
+        case let .plain(s): return s
+        case let .tls(_, _, s): return s
         }
+    }
+    
+    public struct Server {
+        var host: String
+        var port: Int
+        var user: String
+        var password: String
+        var vhost: String
+        var timeout: TimeAmount
+        var connectionName: String
+        
+        public init(host: String? = nil,
+                    port: Int? = nil,
+                    user: String? = nil,
+                    password: String? = nil,
+                    vhost: String? = nil,
+                    timeout: TimeAmount? = nil,
+                    connectionName: String? = nil) {
+            
+            self.host = host ?? Defaults.host
+            self.port = port ?? Defaults.port
+            self.user = user ?? Defaults.user
+            self.password = password ?? (user == nil ? Defaults.password : "")
+            self.vhost = vhost ?? Defaults.vhost
+            self.timeout = timeout ?? Defaults.timeout
+            self.connectionName = connectionName ?? Defaults.connectionName
+        }
+    }
+}
+
+@available(macOS 13.0, *)
+public extension AMQPClientConfiguration {
+    
+    enum ValidationError: Error, Equatable {
+        case invalidUrl
+        case invalidScheme
+    }
+    
+    enum UrlScheme: String {
+        case amqp = "amqp"
+        case amqps = "amqps"
+        
+        var defaultPort: Int {
+            switch self {
+            case .amqp: return Server.Defaults.port
+            case .amqps: return Server.Defaults.tlsPort
+            }
+        }
+    }
+    
+    init(url: String) throws {
+        guard let url = URL(string: url) else { throw ValidationError.invalidUrl }
+        try self.init(url: url)
+    }
+    
+    init(url: URL) throws {
+        guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw ValidationError.invalidScheme }
+        
+        // there is no such thing as a "" host
+        let host = url.host?.isEmpty == true ? nil : url.host
+        //special path magic for vhost interpretation (see https://www.rabbitmq.com/uri-spec.html)
+        let vhost = url.path.isEmpty ? nil : String(url.path(percentEncoded: false).dropFirst())
+        let server = Server(host: host, port: url.port ?? scheme.defaultPort, user: url.user, password: url.password?.removingPercentEncoding, vhost: vhost)
+        
+        switch scheme {
+        case .amqp: self = .plain(server)
+        case .amqps: self = .tls(nil, sniServerName: nil, server)
+        }
+    }
+}
+
+extension AMQPClientConfiguration.Server {
+    struct Defaults {
+        static let host = "localhost"
+        static let port = 5672
+        static let tlsPort = 5671
+        static let user = "guest"
+        static let password = "guest"
+        static let vhost = "/"
+        static var timeout: TimeAmount { TimeAmount.seconds(60) }
+        //NOTE: seems like an unneccassary dependency on Foundation / Bundle / NSString
+        static var connectionName: String { ((Bundle.main.executablePath ?? "RabbitMQNIO") as NSString).lastPathComponent }
     }
 }

--- a/Sources/AMQPClient/AMQPClientError.swift
+++ b/Sources/AMQPClient/AMQPClientError.swift
@@ -14,6 +14,8 @@
 import AMQPProtocol
 
 public enum AMQPClientError: Error {
+    case invalidUrl
+    case invalidUrlScheme
     case alreadyShutdown
     case tooManyOpenedChannels
     case alreadyConnected

--- a/Tests/AMQPClientTests/AMQPChannelTest.swift
+++ b/Tests/AMQPClientTests/AMQPChannelTest.swift
@@ -5,6 +5,7 @@ import NIO
 
 @testable import AMQPClient
 
+@available(macOS 12.0, *)
 final class AMQPChannelTest: XCTestCase {
     var client = AMQPClient(eventLoopGroupProvider: .createNew, config: .plain(.init()))
 

--- a/Tests/AMQPClientTests/AMQPClientConfigurationTest.swift
+++ b/Tests/AMQPClientTests/AMQPClientConfigurationTest.swift
@@ -1,0 +1,67 @@
+import XCTest
+import AMQPClient
+@testable import AMQPClient
+
+@available(macOS 13.0, *)
+final class AMQPClientConfigurationTest: XCTestCase {
+
+    func testFromPlainURL() throws {
+        guard case let .plain(config) = try AMQPClientConfiguration(url: "amqp://myUser:myPass@myHost:1234/myVHost?some=junk") else { return XCTFail("plain expected") }
+
+        XCTAssertEqual(config.host, "myHost")
+        XCTAssertEqual(config.port, 1234)
+        XCTAssertEqual(config.user, "myUser")
+        XCTAssertEqual(config.password, "myPass")
+        XCTAssertEqual(config.vhost, "myVHost")
+    }
+    
+    func testFromPlainURLWithDefaults() throws {
+        guard case let .plain(config) = try AMQPClientConfiguration(url: "amqp://myHost") else { return XCTFail("plain expected") }
+
+        XCTAssertEqual(config.host, "myHost")
+        XCTAssertEqual(config.port, 5672)
+        XCTAssertEqual(config.user, "guest")
+        XCTAssertEqual(config.password, "guest")
+        XCTAssertEqual(config.vhost, "/")
+    }
+    
+    func testFromTlsURLWithOnlyUserAndPassword() throws {
+        guard case let .tls(_, _, config) = try AMQPClientConfiguration(url: "amqps://top:secret@") else { return XCTFail("tls expected") }
+
+        XCTAssertEqual(config.host, "localhost")
+        XCTAssertEqual(config.port, 5671)
+        XCTAssertEqual(config.user, "top")
+        XCTAssertEqual(config.password, "secret")
+        XCTAssertEqual(config.vhost, "/")
+    }
+    
+    func testWithEmpties() throws {
+        let c = try AMQPClientConfiguration(url: "amqp://@:/")
+
+        XCTAssertEqual(c.server.host, "localhost")
+        XCTAssertEqual(c.server.port, 5672)
+        XCTAssertEqual(c.server.user, "")
+        XCTAssertEqual(c.server.password, "")
+        XCTAssertEqual(c.server.vhost, "")
+    }
+    
+    func testWithUrlEncodedVHost() throws {
+        let c = try AMQPClientConfiguration(url: "amqps://hello@host:1234/%2f")
+
+        XCTAssertEqual(c.server.host, "host")
+        XCTAssertEqual(c.server.port, 1234)
+        XCTAssertEqual(c.server.user, "hello")
+        XCTAssertEqual(c.server.password, "")
+        XCTAssertEqual(c.server.vhost, "/")
+    }
+    
+    func testWithUrlEncodedEverything() throws {
+        let c = try AMQPClientConfiguration(url: "amqp://user%61:%61pass@ho%61st:10000/v%2fhost")
+
+        XCTAssertEqual(c.server.host, "hoast")
+        XCTAssertEqual(c.server.port, 10000)
+        XCTAssertEqual(c.server.user, "usera")
+        XCTAssertEqual(c.server.password, "apass")
+        XCTAssertEqual(c.server.vhost, "v/host")
+    }
+}

--- a/Tests/AMQPClientTests/AMQPClientTest.swift
+++ b/Tests/AMQPClientTests/AMQPClientTest.swift
@@ -2,6 +2,7 @@ import XCTest
 import AMQPClient
 @testable import AMQPClient
 
+@available(macOS 12.0, *)
 final class AMQPClientTest: XCTestCase {
     var client = AMQPClient(eventLoopGroupProvider: .createNew, config: .plain(.init()))
 


### PR DESCRIPTION
I don't like the dependency on URL - especially the path bit that requires an @available attribute... (only the new version works with the /%2f vhost case)

but it does the job for #2 