### PR TITLE
connection state instead of managed atomic

### DIFF
--- a/Sources/AMQPClient/AMQPClientError.swift
+++ b/Sources/AMQPClient/AMQPClientError.swift
@@ -18,8 +18,7 @@ public enum AMQPClientError: Error {
     case invalidUrlScheme
     case alreadyShutdown
     case tooManyOpenedChannels
-    case alreadyConnecting
-    case alreadyConnected
+    case alreadyConnect
     case connectionClosed(replyCode: UInt16? = nil, replyText: String? = nil)
     case channelClosed(replyCode: UInt16? = nil, replyText: String? = nil)
     case channelAlreadyReserved


### PR DESCRIPTION
Fix for: [#10](https://github.com/funcmike/rabbitmq-nio/issues/10)