### PR TITLE
Small quality of life updates for AMQPConnectionConfiguration

### DIFF
--- a/Sources/AMQPClient/AMQPConnectionConfiguration.swift
+++ b/Sources/AMQPClient/AMQPConnectionConfiguration.swift
@@ -71,12 +71,12 @@ public extension AMQPConnectionConfiguration {
         }
     }
     
-    init(url: String) throws {
+    init(url: String, tls: TLSConfiguration? = nil) throws {
         guard let url = URL(string: url) else { throw AMQPConnectionError.invalidUrl }
-        try self.init(url: url)
+        try self.init(url: url, tls: tls)
     }
-    
-    init(url: URL) throws {
+
+    init(url: URL, tls: TLSConfiguration? = nil) throws {
         guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw AMQPConnectionError.invalidUrlScheme }
         
         // there is no such thing as a "" host
@@ -97,7 +97,7 @@ public extension AMQPConnectionConfiguration {
         
         switch scheme {
         case .amqp: self = .init(connection: .plain, server: server)
-        case .amqps: self = .init(connection: .tls(nil, sniServerName: nil), server: server)
+        case .amqps: self = .init(connection: .tls(tls, sniServerName: nil), server: server)
         }
     }
 }

--- a/Sources/AMQPClient/AMQPConnectionConfiguration.swift
+++ b/Sources/AMQPClient/AMQPConnectionConfiguration.swift
@@ -85,7 +85,7 @@ public extension AMQPConnectionConfiguration {
         var vhost = url.path.isEmpty ? nil : String(url.path.removingPercentEncoding?.dropFirst() ?? "")
 
         // workaround: "/%f" is interpreted as / by URL (this restores %f as /)
-        if url.absoluteString.hasSuffix("%2f") {
+        if url.absoluteString.lowercased().hasSuffix("%2f") {
             if let vh = vhost  {
                 vhost = vh + "/"
             } else {


### PR DESCRIPTION
We have started working with this library to test migrating some applications from C# to Swift, and noticed a few things that could be improved in the library when related to the `AMQPConnectionConfiguration`. Hopefully this can be helpful and included as a small improvement.

 - Add `.lowercased()` to check for "%2f" string as a URL encoded "/" character. Connection strings can come with an uppercase "%2F" and this is completely valid as well.
 - Add `tls` optional parameter for constructors to allow the user of the library to easily provide a custom `TLSConfiguration`.