### PR TITLE
Fix vhost with double slash "//" on Swift 6

### DIFF
--- a/Sources/AMQPClient/AMQPConnectionConfiguration.swift
+++ b/Sources/AMQPClient/AMQPConnectionConfiguration.swift
@@ -86,11 +86,7 @@ public extension AMQPConnectionConfiguration {
 
         // workaround: "/%f" is interpreted as / by URL (this restores %f as /)
         if url.absoluteString.lowercased().hasSuffix("%2f") {
-            if let vh = vhost  {
-                vhost = vh + "/"
-            } else {
-                vhost = "/"
-            }
+            vhost = "/"
         }
 
         let server = Server(host: host, port: url.port ?? scheme.defaultPort, user: url.user, password: url.password?.removingPercentEncoding, vhost: vhost)


### PR DESCRIPTION
In Swift 6, it appears that the call to `url.path.removingPercentEncoding` properly works now, causing it to translate the "%2f" to "/". However, the workaround block of code works incorrectly, adding another slash:

```swift
        if url.absoluteString.lowercased().hasSuffix("%2f") {
            if let vh = vhost  {
                vhost = vh + "/"
            } else {
                vhost = "/"
            }
        }
```

This causes the issue #46 to occur when running an app under Swift 6. This simple PR fixes the issue and still works in Swift 5.x versions. All unit tests also pass.