### PR TITLE
Add more options to AMQPConnectionConfiguration convenience inits

### DIFF
--- a/Sources/AMQPClient/AMQPConnectionConfiguration.swift
+++ b/Sources/AMQPClient/AMQPConnectionConfiguration.swift
@@ -98,7 +98,7 @@ public extension AMQPConnectionConfiguration {
         guard let scheme = UrlScheme(rawValue: url.scheme ?? "") else { throw AMQPConnectionError.invalidUrlScheme }
 
         // there is no such thing as a "" host
-        let host = url.host?.isEmpty == true ? nil : url.host
+        let host = url.host?.isEmpty == true ? nil : url.host?.removingPercentEncoding
         //special path magic for vhost interpretation (see https://www.rabbitmq.com/uri-spec.html)
         var vhost = url.path.isEmpty ? nil : String(url.path.removingPercentEncoding?.dropFirst() ?? "")
 

--- a/Sources/AMQPClient/AMQPConnectionConfiguration.swift
+++ b/Sources/AMQPClient/AMQPConnectionConfiguration.swift
@@ -109,7 +109,7 @@ public extension AMQPConnectionConfiguration {
 
         let server = Server(
             host: host, port: url.port ?? scheme.defaultPort,
-            user: url.user, password: url.password?.removingPercentEncoding,
+            user: url.user?.removingPercentEncoding,password: url.password?.removingPercentEncoding,
             vhost: vhost, timeout: timeout, connectionName: connectionName
         )
 


### PR DESCRIPTION
I was updating my [swift-rabbitmq](https://github.com/xtremekforever/swift-rabbitmq) abstraction library (which depends on rabbitmq-nio) and ran into the problem of not being able to provide a custom timeout or connectionName to the .init methods that are used for convenience. So I added them as parameters to the 2 convenience inits and added some tests for them.

 - These options are defaulted to nil so that if they are not provided, the defaults are used.
 - Also cleaned up some whitespace in edited files.