### PR TITLE
fix: only reply with cancel ok if requested

### DIFF
--- a/Sources/AMQPClient/ChannelHandlers/AMQPConnectionMultiplexHandler.swift
+++ b/Sources/AMQPClient/ChannelHandlers/AMQPConnectionMultiplexHandler.swift
@@ -220,8 +220,10 @@ internal final class AMQPConnectionMultiplexHandler: ChannelDuplexHandler {
                 case let .cancel(cancel):
                     channel.eventHandler?.handleCancellation(consumerTag: cancel.consumerTag)
 
-                    let cancelOk = Frame(channelID: frame.channelID, payload: .method(.basic(.cancelOk(consumerTag: cancel.consumerTag))))
-                    context.writeAndFlush(wrapOutboundOut(.frame(cancelOk)), promise: nil)
+                    if !cancel.noWait {
+                        let cancelOk = Frame(channelID: frame.channelID, payload: .method(.basic(.cancelOk(consumerTag: cancel.consumerTag))))
+                        context.writeAndFlush(wrapOutboundOut(.frame(cancelOk)), promise: nil)
+                    }
                 case let .ack(deliveryTag, multiple):
                     channel.eventHandler?.receivePublishConfirm(.ack(deliveryTag: deliveryTag, multiple: multiple))
                 case let .nack(nack):


### PR DESCRIPTION
When the server sends a Basic Cancel, the client should only reply when noWait = false.
Otherwise we get a 503 error because the server is not expecting any reply when noWait = true.
I added the check for that.